### PR TITLE
Updating the generic-socialpic Sample

### DIFF
--- a/column-samples/generic-socialpic/README.md
+++ b/column-samples/generic-socialpic/README.md
@@ -26,7 +26,7 @@ Version|Date|Comments
 -------|----|--------
 1.0|July 21, 2018|Initial release
 1.1|August 20, 2018|Updated to use Excel-style expressions
-1.2|August 20, 2020|Updated to use the unavatar service
+1.2|August 20, 2020|Updated to use the unavatar service for profile picture
 
 ## Disclaimer
 **THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.**

--- a/column-samples/generic-socialpic/README.md
+++ b/column-samples/generic-socialpic/README.md
@@ -2,31 +2,17 @@
 
 ## Summary
 
-Using the social media handles supported by https://avatars.io, social media profile pictures are displayed in a circle and clicking them will open the user's social media page in a new window. The handle is also displayed as a tooltip when hovering over the profile image.
+Using the social media handles supported by https://unavatar.now.sh, social media profile pictures are displayed in a circle and clicking them will open the user's social media page in a new window. The handle is also displayed as a tooltip when hovering over the profile image.
 
 ![screenshot of the sample](./screenshot.png)
-> Note: https://avatars.io currently supports Twitter, Facebook, Instagram and Gravatar
-
-
-### Image Size
-
-[avatars.io](https://avatars.io) come in 3 standard sizes:
-
-|Name|Size|
-|---|:---:|
-|small|48x48|
-|medium|128x128|
-|large|256x256|
-
-To change the size, adjust the portion of the `src` url to use the keyword from the table above and then adjust the `width` and `height` style attributes for the containing `div`.
+> Note: https://unavatar.now.sh currently supports a variety of services including Twitter, Facebook, Instagram and GitHub.
 
 ### Column Types
 This format will work with Choice and Text columns without any changes. To use Lookup columns, you'll need to change the 2 occurences of `@currentField` to `@currentField.lookupValue`.
 
 The field values are case insensitve and should be just the user's twitter handle with no @.
 
-## View requirements
-- 
+
 
 ## Sample
 
@@ -40,6 +26,7 @@ Version|Date|Comments
 -------|----|--------
 1.0|July 21, 2018|Initial release
 1.1|August 20, 2018|Updated to use Excel-style expressions
+1.2|August 20, 2020|Updated to use the unavatar service
 
 ## Disclaimer
 **THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.**

--- a/column-samples/generic-socialpic/generic-socialpic.json
+++ b/column-samples/generic-socialpic/generic-socialpic.json
@@ -23,7 +23,7 @@
               {
                 "elmType": "img",
                 "attributes": {
-                  "src": "='https://avatars.io/' + [$Social_x0020_Network] + '/' + @currentField + '/medium'",
+                  "src": "='https://unavatar.now.sh/' + [$Social_x0020_Network] + '/' + @currentField + '/medium'",
                   "alt": "='@' + @currentField"
                 },
                 "style": {

--- a/column-samples/generic-socialpic/generic-socialpicAST.json
+++ b/column-samples/generic-socialpic/generic-socialpicAST.json
@@ -40,7 +40,7 @@
                   "src": {
                     "operator": "+",
                     "operands": [
-                      "https://avatars.io/",
+                      "https://unavatar.now.sh/",
                       "[$Social_x0020_Network]",
                       "/",
                       "@currentField",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes


#### What's in this Pull Request?
Updated the sample to replace the now unavailable "avatars.io" with the "https://unavatar.now.sh/" service for pulling in the profile picture of the social account.
